### PR TITLE
Bump version to 1.5.1

### DIFF
--- a/api.json
+++ b/api.json
@@ -1,7 +1,7 @@
 {
  "openapi":"3.0.2",
  "info": {
-   "version":"1.4.13",
+   "version":"1.5.1",
    "title":"Rosetta",
    "description":"Build Once. Integrate Your Blockchain Everywhere.",
    "license": {

--- a/api.yaml
+++ b/api.yaml
@@ -14,7 +14,7 @@
 
 openapi: 3.0.2
 info:
-  version: 1.4.13
+  version: 1.5.1
   title: Rosetta
   description: |
     Build Once. Integrate Your Blockchain Everywhere.


### PR DESCRIPTION
### Motivation

The current version is not correct. We did a 1.4.15 release, but then that we serve the '1.4.13' string from the api.json which messes with the mesh-sdk-go update.

Hence, I'll merge this, and then make a new `1.5.1` release where the api.json and api.yaml version